### PR TITLE
Added simple link resolution for BCL types

### DIFF
--- a/Src/ImmDocNet/ImmDocNet/Properties/AssemblyInfo.cs
+++ b/Src/ImmDocNet/ImmDocNet/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("c7681ac8-b498-487d-a8d2-8b87fcbefc29")]
 
-[assembly: AssemblyVersion("1.0.6.0")]
+[assembly: AssemblyVersion("1.0.7.0")]

--- a/Src/ImmDocNet/ImmDocNetLib.Tests/Properties/AssemblyInfo.cs
+++ b/Src/ImmDocNet/ImmDocNetLib.Tests/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("0687daae-7531-499c-a9e3-f96c902ae9cd")]
 
-[assembly: AssemblyVersion("1.0.6.0")]
+[assembly: AssemblyVersion("1.0.7.0")]

--- a/Src/ImmDocNet/ImmDocNetLib/Properties/AssemblyInfo.cs
+++ b/Src/ImmDocNet/ImmDocNetLib/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("6effd766-1411-4d6d-8f03-921594af808e")]
 
-[assembly: AssemblyVersion("1.0.6.0")]
+[assembly: AssemblyVersion("1.0.7.0")]

--- a/Src/ImmDocNet/SampleLibrary/Properties/AssemblyInfo.cs
+++ b/Src/ImmDocNet/SampleLibrary/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("46a74047-9752-4de9-9fcd-0bfb50fe0dfc")]
 
-[assembly: AssemblyVersion("1.0.6.0")]
+[assembly: AssemblyVersion("1.0.7.0")]

--- a/Src/ImmDocNet/SampleLibrary2/Properties/AssemblyInfo.cs
+++ b/Src/ImmDocNet/SampleLibrary2/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("547dd1b7-184d-47c8-9c96-48ce2c91b805")]
 
-[assembly: AssemblyVersion("1.0.6.0")]
+[assembly: AssemblyVersion("1.0.7.0")]


### PR DESCRIPTION
Unresolved types in System and Microsoft namespaces will generate MSDN links, i.e.:
System.AppDomain -> http://msdn.microsoft.com/library/system.appdomain.aspx
- If user assembly has a type defined in System or Microsoft namespace, the link will point to the user type.
- Type name is not checked for validity, it's blindly converted to a link as long as it matches the regex (i.e. System.Foo.Bar will create a link to a non-existing MSDN page).
- MSDN links get additional target="_top" attribute, so they aren't opened inside the frame.
